### PR TITLE
Policy support

### DIFF
--- a/abi/cwa/core.go
+++ b/abi/cwa/core.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/perlin-network/life/exec"
 	"within.website/olin/abi"
+	"within.website/olin/policy"
 )
 
 // NewProcess creates a new process with the given name, arguments and environment.
@@ -38,6 +39,7 @@ type Process struct {
 	vm           *exec.VirtualMachine
 	argv         []string
 	syscallCount int64
+	Policy       *policy.Policy
 
 	FileHandles    map[int32]abi.File
 	Stdin          io.Reader

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -1,0 +1,54 @@
+# Policy Files
+
+Olin offers the ability to customize what the guest webassembly environment can
+and cannot access by using a policy file. Here are the options you can put in
+one:
+
+```
+## This is a comment. All comments require two hashes.
+
+## This is the list of URL matching regexes that the environment is explicitly
+## allowed to open. Any resource URL not matching one of these regexes will be
+## denied and the webassembly module will be immediately killed.
+allow (
+  https://mycoolsite.com
+  https://discordapp.com/api/webhooks
+  random://
+  zero://
+)
+
+## This is the list of URL matching regexes that the environment is explicitly
+## disallowed from opening. Any resource URL matching one of these regexes will
+## be denied and the webassembly module will be immediately killed.
+disallow (
+  https://mycoolsite.com/admin
+)
+
+## This is the ram limit in webassembly pages. The default is 128 pages, or
+## about eight megabytes.
+ram-page-limit 128
+
+## This is the gas limit. This defines how many webassembly instructions the
+## environment is allowed to execute. If it goes over this number, the
+## webassembly module gets immediately killed. The default is over 33 million
+## instructions.
+gas-limit 33554432
+```
+
+Or more minimally:
+
+```
+allow (
+  https://mycoolsite.com
+  https://discordapp.com/api/webhooks
+  random://
+  zero://
+)
+
+disallow (
+  https://mycoolsite.com/admin
+)
+
+ram-page-limit 128
+gas-limit 33554432
+```

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,14 @@ module within.website/olin
 require (
 	github.com/google/uuid v1.0.0
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
+	github.com/kr/pretty v0.1.0
+	github.com/mkmik/stringlist v1.0.1
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709
 	github.com/perlin-network/life v0.0.0-20191203030451-05c0e0f7eaea
 	github.com/povilasv/prommod v0.0.12
 	github.com/prometheus/client_golang v1.2.1
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
+	within.website/confyg v1.1.0
 	within.website/ln v0.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,15 @@ github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mkmik/stringlist v1.0.1 h1:wOGoAqZusN1bbqhwkcdiMB8z/uOnJGnciKrWXWPXyW4=
+github.com/mkmik/stringlist v1.0.1/go.mod h1:TyqoldqwIeKUiL8vmAjYzu0qZfSP3cXVxTAfgBpw/TE=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -116,5 +123,11 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+within.website/confyg v0.4.0 h1:FklkpJyMLYBxECCI4RS4R2c/x7PblOvbX0qBjk8Wkjs=
+within.website/confyg v0.4.0/go.mod h1:KD5rDgkE3B+vbDiH/usiuK+CfiOkCiuD87NEF3/budk=
+within.website/confyg v1.0.0 h1:LXRvRCiAMlA7YP0pvdl0UKJXC5GEoZio6OIru0fwpu4=
+within.website/confyg v1.0.0/go.mod h1:KD5rDgkE3B+vbDiH/usiuK+CfiOkCiuD87NEF3/budk=
+within.website/confyg v1.1.0 h1:FIOQfsKwZyjiqKE8NGlmqe9DzMPHMruuK0I/2cnmTIs=
+within.website/confyg v1.1.0/go.mod h1:KD5rDgkE3B+vbDiH/usiuK+CfiOkCiuD87NEF3/budk=
 within.website/ln v0.7.0 h1:cZUc53cZF/+hWuEAv1VbqlYJ5czuPFHKfH0hLKmlIUA=
 within.website/ln v0.7.0/go.mod h1:ifURKqsCJekcsdUE+hyCdcuhQqQ+9v9DfA++ZqYxZFE=

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,0 +1,51 @@
+package policy
+
+import (
+	"flag"
+	"regexp"
+
+	"github.com/mkmik/stringlist"
+	"within.website/confyg/flagconfyg"
+)
+
+type Policy struct {
+	Allowed      []*regexp.Regexp
+	Disallowed   []*regexp.Regexp
+	RamPageLimit uint
+	GasLimit     uint
+}
+
+func Parse(name string, data []byte) (Policy, error) {
+	var result Policy
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+
+	var allowed stringlist.Value
+	var disallowed stringlist.Value
+	fs.Var(&allowed, "allow", "the list of file URL's that are allowed")
+	fs.Var(&disallowed, "disallow", "the list of file URL's that are disallowed")
+	fs.UintVar(&result.RamPageLimit, "ram-page-limit", 128, "the ram page limit")
+	fs.UintVar(&result.GasLimit, "gas-limit", 32*1024*1024, "the number of wasm instructions that can be run")
+
+	err := flagconfyg.Parse(name, data, fs)
+	if err != nil {
+		return Policy{}, err
+	}
+
+	for _, allow := range []string(allowed) {
+		rex, err := regexp.Compile(allow)
+		if err != nil {
+			return Policy{}, err
+		}
+		result.Allowed = append(result.Allowed, rex)
+	}
+
+	for _, disallow := range []string(disallowed) {
+		rex, err := regexp.Compile(disallow)
+		if err != nil {
+			return Policy{}, err
+		}
+		result.Disallowed = append(result.Disallowed, rex)
+	}
+
+	return result, nil
+}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -1,0 +1,23 @@
+package policy
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	for _, file := range []string{"gitea.policy"} {
+		t.Run(file, func(t *testing.T) {
+			data, err := ioutil.ReadFile(filepath.Join("./testdata", file))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = Parse(file, data)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/policy/testdata/gitea.policy
+++ b/policy/testdata/gitea.policy
@@ -1,0 +1,20 @@
+## This is an example policy
+
+## These are the URL patterns that this handler can open
+allow (
+  https://tulpa.dev
+  https://discordapp.com/api/webhooks/
+  random://
+)
+
+## These are the URL patterns that this handler cannot open
+disallow (
+  file://
+  .*
+)
+
+## This is the ram limit in pages
+ram-page-limit 128
+
+## This is the gas limit in instructions
+gas-limit 1048576

--- a/zig/test.sh
+++ b/zig/test.sh
@@ -19,3 +19,11 @@ then
     echo "expected exit status 1, got: $status"
     exit 1
 fi
+
+cwa -policy ../policy/testdata/gitea.policy httptest.wasm
+status=$?
+if [ $status -ne 1 ]
+then
+    echo "expected exit status 1, got: $status"
+    exit 1
+fi


### PR DESCRIPTION
Ref https://tulpa.dev/within/wasmcloud/issues/12

This allows developers to write policies for what resources a webassembly file can and cannot open. Any violations will result in a vibe check failing, followed by the termination of the webassembly program.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xe/olin/105)
<!-- Reviewable:end -->
