### PR TITLE
allow pure build of zig derivation

### DIFF
--- a/nix/zig.nix
+++ b/nix/zig.nix
@@ -1,3 +1,5 @@
 { sources ? import ./sources.nix, pkgs ? import sources.nixpkgs { } }:
 
-(import ./zig_raw.nix { }) "0.6.0"
+(import ./zig_raw.nix {
+  inherit sources pkgs;
+}) "0.6.0"


### PR DESCRIPTION
Just one commit, here's the message:
```
allow pure build of zig derivation

Prior to this commit, if nixpkgs was imported with a definite system, it
would *mostly* work as intended and not make impure calls to Nix's
builtins.CurrentSystem, except for here in zig_raw.nix, which doesn't
respect sources and pkgs. The solution is simple: just inherit sources
and pkgs when we make a versioned zig_raw in zig.nix.
```

I've tested that this successfully builds and that tests run, so I don't think this should cause any problems!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xe/olin/135)
<!-- Reviewable:end -->
